### PR TITLE
fix calcQ2 used to not work

### DIFF
--- a/utils/KinTool.groovy
+++ b/utils/KinTool.groovy
@@ -8,15 +8,19 @@ class KinTool{
     //move somplace else
 
     static def calcQ2(LorentzVector beam, LorentzVector measured_el){
-	return -(beam-measured_el).mass2()
+        LorentzVector VGS = new LorentzVector(beam)
+        VGS.sub(measured_el)
+	return -VGS.mass2()
     }
 
     static def calcXb(LorentzVector beam, LorentzVector measured_el){
-	return calcQ2(beam,measured_el)/(2.0*PDGDatabase.getParticleMass(2212)*(beam-measured_el).e())
+        LorentzVector VGS = new LorentzVector(beam)
+        VGS.sub(measured_el)
+	return calcQ2(beam,measured_el)/(2.0*PDGDatabase.getParticleMass(2212)*VGS.e())
     }
 
     static def calcT(LorentzVector measured_prot){
-	return 2.0*PDGDatabase.getParticleMass(2212)*(measured_prot-PDGDatabase.getParticleMass(2212))
+	return 2.0*PDGDatabase.getParticleMass(2212)*(measured_prot.e()-PDGDatabase.getParticleMass(2212))
     }
 
     static def calcNu(LorentzVector beam, LorentzVector measured_el){
@@ -29,7 +33,9 @@ class KinTool{
 
     static def calcPhiTrento(LorentzVector beam, LorentzVector measured_el,LorentzVector measured_prot){
 	def v3l = beam.vect().cross(measured_el.vect())
-	def v3h = measured_prot.vect().cross((beam-measured_el).vect())
+    LorentzVector VGS = new LorentzVector(beam)
+    VGS.sub(measured_el)
+	def v3h = measured_prot.vect().cross(VGS.vect())
 	def trento = Math.toDegrees(Math.acos(v3l.dot(v3h)/(v3l.mag()*v3h.mag())))
 
 	if(v3l.dot(measured_prot.vect())<0){trento=360-trento}


### PR DESCRIPTION
1. LorentzVector can't be simply subtracted or added. Use temporary variables for operations, such as VGS.
2. Typo orrected at calcT